### PR TITLE
revamped readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you get stuck and need help, I've written a [walkthrough](https://digi.ninja/
 
 If you want to have a play, but do not want to install it yourself, you can use [my copy](https://vulndap.digi.ninja/). Please do not abuse this, the vulnerabilities are in the application, do not expect to get anywhere with port scans or by running Nessus against it.
 
-## Installation
+## Building 
 
 ```
 go get github.com/digininja/vuLnDAP
@@ -27,6 +27,18 @@ go build
 ```
 
 And if all goes well you'll get a vuLnDAP binary which you can run with:
+
+## Configuration
+
+```
+cp vulndap.cfg-sample vulndap.cfg
+```
+
+Prior to Usage, ensure that a `vulndap.cfg` file exists
+
+
+## Usage 
+
 
 ```
 ./vuLnDAP

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you get stuck and need help, I've written a [walkthrough](https://digi.ninja/
 
 If you want to have a play, but do not want to install it yourself, you can use [my copy](https://vulndap.digi.ninja/). Please do not abuse this, the vulnerabilities are in the application, do not expect to get anywhere with port scans or by running Nessus against it.
 
-## Building 
+## Installation
 
 ```
 go get github.com/digininja/vuLnDAP
@@ -28,17 +28,50 @@ go build
 
 And if all goes well you'll get a vuLnDAP binary which you can run with:
 
-## Configuration
+```
+./vuLnDAP
+```
+
+The web server starts up listening on port 9090 on all interfaces, this can be changed by updating the values in the webserver section of vulndap.cfg.
+
+
+
+## Building from Source
+
+```
+git clone https://github.com/digininja/vuLnDAP.git
+
+cd vuLnDAP
+```
+
+Clone the repository, then change into that directory
+
+```
+go get 
+```
+
+Download all the necessary 3rd Party Packages
+
+
+```
+go build
+```
+
+Build all the files to create a `./vuLnDAP` binary
+
+
+### Configuration
 
 ```
 cp vulndap.cfg-sample vulndap.cfg
 ```
 
-Prior to Usage, ensure that a `vulndap.cfg` file exists
+Prior to Usage, ensure that a `vulndap.cfg` file exists. For default configurations, refer to `vulndap.cfg-sample`
 
 
-## Usage 
+### Usage 
 
+In order to run, ensure that you have successfully built a `./vuLnDAP` binary. If so simply run:
 
 ```
 ./vuLnDAP


### PR DESCRIPTION
- Added Section for Building from Source, this should happen if #3 is accepted as the `go get` command will work after having `go.mod` and `go.sum` files

- Made it explicit to also be cognizant of the `vulndap.cfg` file